### PR TITLE
Implement BufReader & BufWriter

### DIFF
--- a/src/buf_reader.rs
+++ b/src/buf_reader.rs
@@ -1,0 +1,155 @@
+use {AsyncRead, DEFAULT_BUF_SIZE};
+
+use bytes::BufMut;
+
+use futures::{Async, Poll};
+
+use std::{cmp, fmt};
+use std::io::{self, BufRead, SeekFrom};
+
+/// The `BufReader` struct adds buffering to any reader.
+pub struct BufReader<R> {
+    inner: R,
+    buf: Box<[u8]>,
+    pos: usize,
+    cap: usize,
+}
+
+impl<R: io::Read> BufReader<R> {
+    /// Creates a new `BufReader` with a default buffer capacity.
+    pub fn new(inner: R) -> BufReader<R> {
+        BufReader::with_capacity(DEFAULT_BUF_SIZE, inner)
+    }
+
+    /// Creates a new `BufReader` with the specified buffer capacity.
+    pub fn with_capacity(cap: usize, inner: R) -> BufReader<R> {
+        BufReader {
+            inner: inner,
+            buf: vec![0; cap].into_boxed_slice(),
+            pos: 0,
+            cap: 0,
+        }
+    }
+}
+
+impl<R> BufReader<R> {
+    /// Gets a reference to the underlying reader.
+    ///
+    /// It is inadvisable to directly read from the underlying reader.
+    pub fn get_ref(&self) -> &R {
+        &self.inner
+    }
+
+    /// Gets a mutable reference to the underlying reader.
+    ///
+    /// It is inadvisable to directly read from the underlying reader.
+    pub fn get_mut(&mut self) -> &mut R {
+        &mut self.inner
+    }
+
+    /// Unwraps this `BufReader`, returning the underlying reader.
+    ///
+    /// Note that any leftover data in the internal buffer is lost.
+    pub fn into_inner(self) -> R {
+        self.inner
+    }
+}
+
+impl<R: io::Read> io::Read for BufReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        // If we don't have any buffered data and we're doing a massive read
+        // (larger than our internal buffer), bypass our internal buffer
+        // entirely.
+        if self.pos == self.cap && buf.len() >= self.buf.len() {
+            return self.inner.read(buf);
+        }
+        let nread = {
+            let mut rem = try!(self.fill_buf());
+            try!(rem.read(buf))
+        };
+        self.consume(nread);
+        Ok(nread)
+    }
+}
+
+impl<R: io::Read> io::BufRead for BufReader<R> {
+    fn fill_buf(&mut self) -> io::Result<&[u8]> {
+        // If we've reached the end of our internal buffer then we need to fetch
+        // some more data from the underlying reader.
+        // Branch using `>=` instead of the more correct `==`
+        // to tell the compiler that the pos..cap slice is always valid.
+        if self.pos >= self.cap {
+            debug_assert!(self.pos == self.cap);
+            self.cap = try!(self.inner.read(&mut self.buf));
+            self.pos = 0;
+        }
+        Ok(&self.buf[self.pos..self.cap])
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.pos = cmp::min(self.pos + amt, self.cap);
+    }
+}
+
+impl<R: io::Seek> io::Seek for BufReader<R> {
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        let result: u64;
+        if let SeekFrom::Current(n) = pos {
+            let remainder = (self.cap - self.pos) as i64;
+            // it should be safe to assume that remainder fits within an i64 as the alternative
+            // means we managed to allocate 8 exbibytes and that's absurd.
+            // But it's not out of the realm of possibility for some weird underlying reader to
+            // support seeking by i64::min_value() so we need to handle underflow when subtracting
+            // remainder.
+            if let Some(offset) = n.checked_sub(remainder) {
+                result = try!(self.inner.seek(SeekFrom::Current(offset)));
+            } else {
+                // seek backwards by our remainder, and then by the offset
+                try!(self.inner.seek(SeekFrom::Current(-remainder)));
+                self.pos = self.cap; // empty the buffer
+                result = try!(self.inner.seek(SeekFrom::Current(n)));
+            }
+        } else {
+            // Seeking with Start/End doesn't care about our buffer length.
+            result = try!(self.inner.seek(pos));
+        }
+        self.pos = self.cap; // empty the buffer
+        Ok(result)
+    }
+}
+
+impl<R: AsyncRead> AsyncRead for BufReader<R> {
+    unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [u8]) -> bool {
+        self.inner.prepare_uninitialized_buffer(buf)
+    }
+
+    fn read_buf<B: BufMut>(&mut self, buf: &mut B) -> Poll<usize, io::Error> {
+        // If we don't have any buffered data and we're doing a massive read
+        // (larger than our internal buffer), bypass our internal buffer
+        // entirely.
+        if self.pos == self.cap && unsafe { buf.bytes_mut().len() } >= self.buf.len() {
+            return self.inner.read_buf(buf);
+        }
+
+        let nread = {
+            let rem = try_nb!(self.fill_buf());
+
+            let nread = cmp::min(rem.len(), buf.remaining_mut());
+            buf.put_slice(&rem[0..nread]);
+
+            nread
+        };
+
+        self.consume(nread);
+        Ok(Async::Ready(nread))
+    }
+}
+
+impl<R: fmt::Debug> fmt::Debug for BufReader<R> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("BufReader")
+            .field("reader", &self.inner)
+            .field("buffer", &format_args!("{}/{}", self.cap - self.pos, self.buf.len()))
+            .finish()
+    }
+}

--- a/src/buf_writer.rs
+++ b/src/buf_writer.rs
@@ -1,0 +1,175 @@
+use {AsyncWrite, DEFAULT_BUF_SIZE};
+
+use bytes::{Buf, BufMut, BytesMut};
+use futures::{Async, Poll};
+
+use std::{cmp, fmt};
+use std::io::{self, SeekFrom};
+
+/// Wraps a writer and buffers its output.
+pub struct BufWriter<W> {
+    inner: W,
+    buf: io::Cursor<BytesMut>,
+}
+
+impl<W: io::Write> BufWriter<W> {
+    /// Creates a new `BufWriter` with a default buffer capacity.
+    pub fn new(inner: W) -> BufWriter<W> {
+        BufWriter::with_capacity(DEFAULT_BUF_SIZE, inner)
+    }
+
+    /// Creates a new `BufWriter` with the specified buffer capacity.
+    pub fn with_capacity(cap: usize, inner: W) -> BufWriter<W> {
+        BufWriter {
+            inner: inner,
+            buf: io::Cursor::new(BytesMut::with_capacity(cap)),
+        }
+    }
+
+    fn flush_once(&mut self) -> io::Result<()> {
+        if !self.buf.has_remaining() {
+            return Ok(());
+        }
+
+        self.do_flush()
+    }
+
+    fn flush_all(&mut self) -> io::Result<()> {
+        while self.buf.has_remaining() {
+            try!(self.do_flush());
+        }
+
+        Ok(())
+    }
+
+    fn do_flush(&mut self) -> io::Result<()> {
+        debug_assert!(self.buf.has_remaining());
+
+        match try!(self.inner.write(self.buf.bytes())) {
+            0 => {
+                return Err(io::Error::new(io::ErrorKind::WriteZero, "failed to
+                                          write the buffered data"));
+            }
+            n => self.buf.advance(n),
+        }
+
+        self.compact_buf();
+
+        Ok(())
+    }
+
+    fn compact_buf(&mut self) {
+        if self.buf.position() as usize == self.buf.get_ref().len() {
+            // Fully written, clear the buffer
+            self.buf.set_position(0);
+            self.buf.get_mut().clear();
+        }
+    }
+}
+
+impl<W> BufWriter<W> {
+    /// Gets a reference to the underlying writer.
+    pub fn get_ref(&self) -> &W {
+        &self.inner
+    }
+
+    /// Gets a mutable reference to the underlying writer.
+    ///
+    /// It is inadvisable to directly write to the underlying writer.
+    pub fn get_mut(&mut self) -> &mut W {
+        &mut self.inner
+    }
+
+    /// Unwraps this `BufWriter`, returning the underlying writer.
+    ///
+    /// The buffer is written out before returning the writer.
+    pub fn into_inner(self) -> W {
+        self.inner
+    }
+}
+
+impl<W: io::Write> io::Write for BufWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let len = buf.len();
+
+        if len > self.buf.get_ref().remaining_mut() {
+            // `buf` can't fit in the internal buffer, so try flushing once.
+            try!(self.flush_once());
+        }
+
+        let mut rem = self.buf.get_ref().remaining_mut();
+
+        if rem == 0 {
+            // No remaining space, flush the rest
+            try!(self.flush_all());
+            rem = self.buf.get_ref().remaining_mut();
+        }
+
+        // If the buffer is empty and `buf` is bigger than the internal buffer,
+        // write directly to the upstream
+        if !self.buf.has_remaining() && len >= rem {
+            return self.inner.write(buf);
+        }
+
+        rem = cmp::min(rem, buf.len());
+
+        self.buf.get_mut().put_slice(&buf[..rem]);
+        Ok(rem)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.flush_all().and_then(|()| self.get_mut().flush())
+    }
+}
+
+impl<W: AsyncWrite> AsyncWrite for BufWriter<W> {
+    fn shutdown(&mut self) -> Poll<(), io::Error> {
+        self.flush_all().and_then(|()| self.get_mut().shutdown())
+    }
+
+    fn write_buf<B: Buf>(&mut self, buf: &mut B) -> Poll<usize, io::Error> {
+        let rem_before = buf.remaining();
+
+        // The first chunk of the buffer cannot fit in the remaining buffer
+        // space, so a flush will be attempted. Now, since the upstream may
+        // supported scatter I/O operations, the original buffer will be
+        // included as well.
+        if buf.bytes().len() > self.buf.get_ref().remaining_mut() {
+            try_ready!(self.inner.write_buf(&mut (&mut self.buf).chain(&mut *buf)));
+            self.compact_buf();
+        }
+
+        // Flush in a loop as long as there is no remaining internal buffer
+        // space, this is because we can't write "0"
+        while !self.buf.get_ref().has_remaining_mut() {
+            try_ready!(self.inner.write_buf(&mut (&mut self.buf).chain(&mut *buf)));
+            self.compact_buf();
+        }
+
+        // If the buffer is empty and `buf`'s first chunk is bigger than the
+        // internal buffer, write directly to the upstream
+        if !self.buf.has_remaining() && buf.bytes().len() > self.buf.get_ref().remaining_mut() {
+            return self.inner.write_buf(buf);
+        }
+
+        // Write to the internal buffer
+        // TODO: I think this may need a take
+        self.buf.get_mut().put(&mut *buf);
+        Ok(Async::Ready(rem_before - buf.remaining()))
+    }
+}
+
+impl<W: fmt::Debug> fmt::Debug for BufWriter<W> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("BufWriter")
+            .field("writer", &self.inner)
+            .field("buffer", &format_args!("{}/{}", self.buf.remaining(), self.buf.get_ref().capacity()))
+            .finish()
+    }
+}
+
+impl<W: io::Write + io::Seek> io::Seek for BufWriter<W> {
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        self.flush_all().and_then(|_| self.get_mut().seek(pos))
+    }
+}

--- a/src/io.rs
+++ b/src/io.rs
@@ -9,6 +9,8 @@
 //! [found online]: https://tokio.rs/docs/getting-started/core/
 //! [low level details]: https://tokio.rs/docs/going-deeper/core-low-level/
 
+pub use buf_reader::BufReader;
+pub use buf_writer::BufWriter;
 pub use copy::{copy, Copy};
 pub use flush::{flush, Flush};
 pub use lines::{lines, Lines};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,8 @@ macro_rules! try_nb {
 pub mod io;
 pub mod codec;
 
+mod buf_reader;
+mod buf_writer;
 mod copy;
 mod flush;
 mod framed;
@@ -66,6 +68,8 @@ mod shutdown;
 mod split;
 mod window;
 mod write_all;
+
+const DEFAULT_BUF_SIZE: usize = 8 * 1024;
 
 use codec::{Decoder, Encoder, Framed};
 use split::{ReadHalf, WriteHalf};

--- a/tests/buf_reader.rs
+++ b/tests/buf_reader.rs
@@ -1,0 +1,171 @@
+extern crate tokio_io;
+
+use tokio_io::io::BufReader;
+
+use std::io::{self, Read, BufRead, SeekFrom, Seek};
+
+/// A dummy reader intended at testing short-reads propagation.
+pub struct ShortReader {
+    lengths: Vec<usize>,
+}
+
+impl Read for ShortReader {
+    fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+        if self.lengths.is_empty() {
+            Ok(0)
+        } else {
+            Ok(self.lengths.remove(0))
+        }
+    }
+}
+
+#[test]
+fn buffered_reader() {
+    let inner: &[u8] = &[5, 6, 7, 0, 1, 2, 3, 4];
+    let mut reader = BufReader::with_capacity(2, inner);
+
+    let mut buf = [0, 0, 0];
+    let nread = reader.read(&mut buf);
+    assert_eq!(nread.unwrap(), 3);
+    let b: &[_] = &[5, 6, 7];
+    assert_eq!(buf, b);
+
+    let mut buf = [0, 0];
+    let nread = reader.read(&mut buf);
+    assert_eq!(nread.unwrap(), 2);
+    let b: &[_] = &[0, 1];
+    assert_eq!(buf, b);
+
+    let mut buf = [0];
+    let nread = reader.read(&mut buf);
+    assert_eq!(nread.unwrap(), 1);
+    let b: &[_] = &[2];
+    assert_eq!(buf, b);
+
+    let mut buf = [0, 0, 0];
+    let nread = reader.read(&mut buf);
+    assert_eq!(nread.unwrap(), 1);
+    let b: &[_] = &[3, 0, 0];
+    assert_eq!(buf, b);
+
+    let nread = reader.read(&mut buf);
+    assert_eq!(nread.unwrap(), 1);
+    let b: &[_] = &[4, 0, 0];
+    assert_eq!(buf, b);
+
+    assert_eq!(reader.read(&mut buf).unwrap(), 0);
+}
+
+#[test]
+fn buffered_reader_seek() {
+    let inner: &[u8] = &[5, 6, 7, 0, 1, 2, 3, 4];
+    let mut reader = BufReader::with_capacity(2, io::Cursor::new(inner));
+
+    assert_eq!(reader.seek(SeekFrom::Start(3)).ok(), Some(3));
+    assert_eq!(reader.fill_buf().ok(), Some(&[0, 1][..]));
+    assert_eq!(reader.seek(SeekFrom::Current(0)).ok(), Some(3));
+    assert_eq!(reader.fill_buf().ok(), Some(&[0, 1][..]));
+    assert_eq!(reader.seek(SeekFrom::Current(1)).ok(), Some(4));
+    assert_eq!(reader.fill_buf().ok(), Some(&[1, 2][..]));
+    reader.consume(1);
+    assert_eq!(reader.seek(SeekFrom::Current(-2)).ok(), Some(3));
+}
+
+#[test]
+fn buffered_reader_seek_underflow() {
+    // gimmick reader that yields its position modulo 256 for each byte
+    struct PositionReader {
+        pos: u64
+    }
+    impl Read for PositionReader {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            let len = buf.len();
+            for x in buf {
+                *x = self.pos as u8;
+                self.pos = self.pos.wrapping_add(1);
+            }
+            Ok(len)
+        }
+    }
+    impl Seek for PositionReader {
+        fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+            match pos {
+                SeekFrom::Start(n) => {
+                    self.pos = n;
+                }
+                SeekFrom::Current(n) => {
+                    self.pos = self.pos.wrapping_add(n as u64);
+                }
+                SeekFrom::End(n) => {
+                    self.pos = u64::max_value().wrapping_add(n as u64);
+                }
+            }
+            Ok(self.pos)
+        }
+    }
+
+    let mut reader = BufReader::with_capacity(5, PositionReader { pos: 0 });
+    assert_eq!(reader.fill_buf().ok(), Some(&[0, 1, 2, 3, 4][..]));
+    assert_eq!(reader.seek(SeekFrom::End(-5)).ok(), Some(u64::max_value()-5));
+    assert_eq!(reader.fill_buf().ok().map(|s| s.len()), Some(5));
+    // the following seek will require two underlying seeks
+    let expected = 9223372036854775802;
+    assert_eq!(reader.seek(SeekFrom::Current(i64::min_value())).ok(), Some(expected));
+    assert_eq!(reader.fill_buf().ok().map(|s| s.len()), Some(5));
+    // seeking to 0 should empty the buffer.
+    assert_eq!(reader.seek(SeekFrom::Current(0)).ok(), Some(expected));
+    assert_eq!(reader.get_ref().pos, expected);
+}
+
+#[test]
+fn read_until() {
+    let inner: &[u8] = &[0, 1, 2, 1, 0];
+    let mut reader = BufReader::with_capacity(2, inner);
+    let mut v = Vec::new();
+    reader.read_until(0, &mut v).unwrap();
+    assert_eq!(v, [0]);
+    v.truncate(0);
+    reader.read_until(2, &mut v).unwrap();
+    assert_eq!(v, [1, 2]);
+    v.truncate(0);
+    reader.read_until(1, &mut v).unwrap();
+    assert_eq!(v, [1]);
+    v.truncate(0);
+    reader.read_until(8, &mut v).unwrap();
+    assert_eq!(v, [0]);
+    v.truncate(0);
+    reader.read_until(9, &mut v).unwrap();
+    assert_eq!(v, []);
+}
+
+#[test]
+fn read_line() {
+    let in_buf: &[u8] = b"a\nb\nc";
+    let mut reader = BufReader::with_capacity(2, in_buf);
+    let mut s = String::new();
+    reader.read_line(&mut s).unwrap();
+    assert_eq!(s, "a\n");
+    s.truncate(0);
+    reader.read_line(&mut s).unwrap();
+    assert_eq!(s, "b\n");
+    s.truncate(0);
+    reader.read_line(&mut s).unwrap();
+    assert_eq!(s, "c");
+    s.truncate(0);
+    reader.read_line(&mut s).unwrap();
+    assert_eq!(s, "");
+}
+
+#[test]
+fn short_reads() {
+    let inner = ShortReader{lengths: vec![0, 1, 2, 0, 1, 0]};
+    let mut reader = BufReader::new(inner);
+    let mut buf = [0, 0];
+    assert_eq!(reader.read(&mut buf).unwrap(), 0);
+    assert_eq!(reader.read(&mut buf).unwrap(), 1);
+    assert_eq!(reader.read(&mut buf).unwrap(), 2);
+    assert_eq!(reader.read(&mut buf).unwrap(), 0);
+    assert_eq!(reader.read(&mut buf).unwrap(), 1);
+    assert_eq!(reader.read(&mut buf).unwrap(), 0);
+    assert_eq!(reader.read(&mut buf).unwrap(), 0);
+}

--- a/tests/buf_writer.rs
+++ b/tests/buf_writer.rs
@@ -1,0 +1,178 @@
+#[macro_use]
+extern crate tokio_io;
+extern crate futures;
+extern crate bytes;
+
+use tokio_io::AsyncWrite;
+use tokio_io::io::BufWriter;
+
+use futures::Poll;
+use futures::Async::*;
+use bytes::{Buf, IntoBuf};
+
+use std::io::{self, Write};
+use std::collections::VecDeque;
+
+macro_rules! mock {
+    ($($x:expr,)*) => {{
+        let mut v = VecDeque::new();
+        v.extend(vec![$($x),*]);
+        Mock { calls: v }
+    }};
+}
+
+macro_rules! assert_would_block {
+    ($x:expr) => {{
+        assert_eq!(io::ErrorKind::WouldBlock, ($x).unwrap_err().kind())
+    }};
+}
+
+#[test]
+fn buffered_writer() {
+    let inner = Vec::new();
+    let mut writer = BufWriter::with_capacity(32, inner);
+
+    assert_eq!(*writer.get_ref(), []);
+
+    writer.write(b"hello world").unwrap();
+    writer.write(b"hello world").unwrap();
+    assert_eq!(*writer.get_ref(), []);
+
+    writer.write(b"hello world").unwrap();
+    assert_eq!(*writer.get_ref(), b"hello worldhello world");
+
+    writer.get_mut().clear();
+
+    writer.flush().unwrap();
+    assert_eq!(*writer.get_ref(), b"hello world");
+
+    writer.get_mut().clear();
+
+    // write a big slice when buffer is empty
+    writer.write(b"hello world hello world hello world").unwrap();
+    assert_eq!(*writer.get_ref(), &b"hello world hello world hello world"[..]);
+}
+
+#[test]
+fn buf_write_would_block() {
+    let mut writer = BufWriter::with_capacity(32, mock! {
+        Ok(b"hello world"[..].into()),
+        Err(would_block()),
+        Ok(b"hello world -- goodbye world"[..].into()),
+        Ok(Flush),
+    });
+
+    assert_eq!(11, writer.write(b"hello world").unwrap());
+    assert_eq!(28, writer.write(b"hello world -- goodbye world").unwrap());
+    assert_would_block!(writer.write(b"2 hello world"));
+
+    assert!(writer.flush().is_ok());
+
+    assert_eq!(13, writer.write(b"2 hello world").unwrap());
+
+    assert!(writer.get_ref().calls.is_empty());
+}
+
+#[test]
+fn buf_write_buf() {
+    const LONG: &'static [u8] = b"1 hello world, 2 hello world, 3 hello world";
+
+    let mut writer = BufWriter::with_capacity(32, mock! {
+        Ok(b"hello world"[..].into()),
+        Ok(LONG.into()),
+    });
+
+    assert_eq!(Ready(11), writer.write_buf(&mut b"hello world".into_buf()).unwrap());
+    assert_eq!(Ready(43), writer.write_buf(&mut LONG.into_buf()).unwrap());
+
+    assert!(writer.get_ref().calls.is_empty());
+}
+
+#[test]
+fn shutdown_flushes() {
+    let mut writer = BufWriter::with_capacity(32, mock! {
+        Ok(b"hello world"[..].into()),
+        Ok(Flush),
+    });
+
+    assert_eq!(11, writer.write(b"hello world").unwrap());
+    assert!(writer.shutdown().unwrap().is_ready());
+
+    assert!(writer.get_ref().calls.is_empty());
+}
+
+// ===== Test utils =====
+
+fn would_block() -> io::Error {
+    io::Error::new(io::ErrorKind::WouldBlock, "would block")
+}
+
+struct Mock {
+    calls: VecDeque<io::Result<Op>>,
+}
+
+enum Op {
+    Data(Vec<u8>),
+    Flush,
+}
+
+use self::Op::*;
+
+impl io::Write for Mock {
+    fn write(&mut self, src: &[u8]) -> io::Result<usize> {
+        match self.calls.pop_front() {
+            Some(Ok(Op::Data(data))) => {
+                let len = data.len();
+                assert!(src.len() >= len, "expect={:?}; actual={:?}", data, src);
+                assert_eq!(&data[..], &src[..len]);
+                Ok(len)
+            }
+            Some(Ok(_)) => panic!(),
+            Some(Err(e)) => Err(e),
+            None => panic!("unexpected write"),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match self.calls.pop_front() {
+            Some(Ok(Op::Flush)) => {
+                Ok(())
+            }
+            Some(Ok(_)) => panic!(),
+            Some(Err(e)) => Err(e),
+            None => panic!("unexpected flush"),
+        }
+    }
+}
+
+impl AsyncWrite for Mock {
+    fn shutdown(&mut self) -> Poll<(), io::Error> {
+        try_nb!(self.flush());
+        Ok(Ready(()))
+    }
+
+    fn write_buf<B: Buf>(&mut self, buf: &mut B) -> Poll<usize, io::Error> {
+        let rem = buf.remaining();
+
+        assert!(rem > 0);
+
+        while buf.has_remaining() {
+            let n = try_nb!(self.write(buf.bytes()));
+            buf.advance(n);
+        }
+
+        Ok(Ready(rem - buf.remaining()))
+    }
+}
+
+impl<'a> From<&'a [u8]> for Op {
+    fn from(src: &'a [u8]) -> Op {
+        Op::Data(src.into())
+    }
+}
+
+impl From<Vec<u8>> for Op {
+    fn from(src: Vec<u8>) -> Op {
+        Op::Data(src)
+    }
+}


### PR DESCRIPTION
This PR pulls in `BufReader` and `BufWriter` from std in order to have greater control

`BufWriter` has somewhat significant changes from the version in std. This is due to the fact that writers passed to tokio's BufWriter will more often than not be non-blocking.

The first significant change is using an internal cursor to track the write position in the buffer. The implementation of `BufWriter` assumed that flushing the buffer will more likely than not flush all the bytes at once. As such, the `drain` on the internal buffer will not require any copying. However, this isn't necessarily the case w/ non-blocking sockets.

The second change is not flushing when calling `into_inner`. Again, a flush has significant chance of failing due to "would block" As such, into_inner can't really rely on this.

Finally, a drop does not attempt to write any data to the upstream. There is no guarantee that a drop occurs on a task, and doing any write operation could panic.