### PR TITLE
Added note about unsafe to doc about AsyncRead::prepare_uninitialized_buffer()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,9 @@ pub trait AsyncRead: std_io::Read {
     /// multiple sub implementations to efficiently implement
     /// `prepare_uninitialized_buffer`.
     ///
+    /// This function isn't actually `unsafe` to call but `unsafe` to implement. The
+    /// implementor must ensure that the whole `buf` has been zeroed.
+    ///
     /// This function is called from [`read_buf`].
     ///
     /// [`io::Read`]: https://doc.rust-lang.org/std/io/trait.Read.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,8 @@ pub trait AsyncRead: std_io::Read {
     /// `prepare_uninitialized_buffer`.
     ///
     /// This function isn't actually `unsafe` to call but `unsafe` to implement. The
-    /// implementor must ensure that either the whole `buf` has been zeroed or `read_buf()`.
+    /// implementor must ensure that either the whole `buf` has been zeroed or `read_buf()`
+    /// overwrites the buffer without reading it and returns correct value.
     ///
     /// This function is called from [`read_buf`].
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ pub trait AsyncRead: std_io::Read {
     /// `prepare_uninitialized_buffer`.
     ///
     /// This function isn't actually `unsafe` to call but `unsafe` to implement. The
-    /// implementor must ensure that the whole `buf` has been zeroed.
+    /// implementor must ensure that either the whole `buf` has been zeroed or `read_buf()`.
     ///
     /// This function is called from [`read_buf`].
     ///


### PR DESCRIPTION
As discussed in [#61 of tokio-core](https://github.com/tokio-rs/tokio-core/issues/61#issuecomment-285864277), documentation is added to explain the purpose of `unsafe` on this fn.