### PR TITLE
add missing methods (into_inner,..)

### DIFF
--- a/src/framed.rs
+++ b/src/framed.rs
@@ -27,6 +27,37 @@ pub fn framed<T, U>(inner: T, codec: U) -> Framed<T, U>
     }
 }
 
+impl<T, U> Framed<T, U> {
+    /// Returns a reference to the underlying I/O stream wrapped by
+    /// `Frame`.
+    ///
+    /// Note that care should be taken to not tamper with the underlying stream
+    /// of data coming in as it may corrupt the stream of frames otherwise
+    /// being worked with.
+    pub fn get_ref(&self) -> &T {
+        &self.inner.get_ref().get_ref().0
+    }
+
+    /// Returns a mutable reference to the underlying I/O stream wrapped by
+    /// `Frame`.
+    ///
+    /// Note that care should be taken to not tamper with the underlying stream
+    /// of data coming in as it may corrupt the stream of frames otherwise
+    /// being worked with.
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.inner.get_mut().get_mut().0
+    }
+
+    /// Consumes the `Frame`, returning its underlying I/O stream.
+    ///
+    /// Note that care should be taken to not tamper with the underlying stream
+    /// of data coming in as it may corrupt the stream of frames otherwise
+    /// being worked with.
+    pub fn into_inner(self) -> T {
+        self.inner.into_inner().into_inner().0
+    }
+}
+
 impl<T, U> Stream for Framed<T, U>
     where T: AsyncRead,
           U: Decoder,

--- a/src/framed_read.rs
+++ b/src/framed_read.rs
@@ -224,6 +224,10 @@ impl<T> FramedRead2<T> {
         &self.inner
     }
 
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+
     pub fn get_mut(&mut self) -> &mut T {
         &mut self.inner
     }

--- a/src/framed_write.rs
+++ b/src/framed_write.rs
@@ -160,6 +160,14 @@ impl<T> FramedWrite2<T> {
     pub fn get_ref(&self) -> &T {
         &self.inner
     }
+
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
 }
 
 impl<T> Sink for FramedWrite2<T>


### PR DESCRIPTION
Add missing methods on Framed

- get_mut
- get_ref
- into_inner

Signed-off-by: Freyskeyd <simon.paitrault@gmail.com>