### PR TITLE
Add the possibility to change the codec of Framed

### DIFF
--- a/src/framed.rs
+++ b/src/framed.rs
@@ -56,6 +56,13 @@ impl<T, U> Framed<T, U> {
     pub fn into_inner(self) -> T {
         self.inner.into_inner().into_inner().0
     }
+
+    /// Consumes the 'Frame', returning a new Frame-stream with the same underlying I/O stream and a different codec.
+    /// 
+    /// Bytes already read into the buffer will be transferred to the new codec
+    pub fn change_codec<UNew>(self, codec: UNew) -> Framed<T, UNew> {
+        Framed { inner: self.inner.replace_inner(|fr| fr.replace_inner(|fuse| Fuse(fuse.0, codec))) }
+    }
 }
 
 impl<T, U> Stream for Framed<T, U>

--- a/src/framed_read.rs
+++ b/src/framed_read.rs
@@ -231,6 +231,15 @@ impl<T> FramedRead2<T> {
     pub fn get_mut(&mut self) -> &mut T {
         &mut self.inner
     }
+
+    pub fn replace_inner<NewT, F: FnOnce(T) -> NewT>(self, newt: F) -> FramedRead2<NewT> {
+        FramedRead2 {
+            inner: newt(self.inner),
+            eof: self.eof,
+            is_readable: self.is_readable,
+            buffer: self.buffer
+        }
+    }
 }
 
 impl<T> Stream for FramedRead2<T>

--- a/src/framed_write.rs
+++ b/src/framed_write.rs
@@ -168,6 +168,10 @@ impl<T> FramedWrite2<T> {
     pub fn get_mut(&mut self) -> &mut T {
         &mut self.inner
     }
+
+    pub fn replace_inner<TNew, F: FnOnce(T) -> TNew>(self, new_inner: F) -> FramedWrite2<TNew> {
+        FramedWrite2 { inner: new_inner(self.inner), buffer: self.buffer }
+    }
 }
 
 impl<T> Sink for FramedWrite2<T>


### PR DESCRIPTION
I added a function to replace the codec of the Framed object.

My usecase for this are websockets. It starts with a simple line-based codec (or http-codec). After a connection upgrade to websockets are negotiogated, the frames change to a different codec.

If the codec change happends to occur after the first websocket was received by the tcp-stream, I am afraid those bytes are lost. So I added a simpel function to prevent this race condition by replacing the existing codec with a new codec and reuse the buffers.