### PR TITLE
Add the possibility to change the codec of Framed with FramedParts

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -10,7 +10,7 @@
 //! [`Stream`]: #
 //! [transports]: #
 
-pub use framed::Framed;
+pub use framed::{Framed, FramedParts};
 pub use framed_read::{FramedRead, Decoder};
 pub use framed_write::{FramedWrite, Encoder};
 

--- a/src/framed.rs
+++ b/src/framed.rs
@@ -197,10 +197,16 @@ impl<T, U: Encoder> Encoder for Fuse<T, U> {
     }
 }
 
+/// `FramedParts` contains an export of the data of a Framed transport.
+/// It can be used to construct a new `Framed` with a different codec.
+/// It contains all current buffers and the inner transport.
 #[derive(Debug)]
 pub struct FramedParts<T>
 {
+    /// The inner transport used to read bytes to and write bytes to
     pub inner: T,
+    /// The buffer with read but unprocessed data.
     pub readbuf: BytesMut,
+    /// A buffer with unprocessed data which are not written yet.
     pub writebuf: BytesMut
 }

--- a/src/framed_read.rs
+++ b/src/framed_read.rs
@@ -219,6 +219,15 @@ pub fn framed_read2<T>(inner: T) -> FramedRead2<T> {
     }
 }
 
+pub fn framed_read2_with_buffer<T>(inner: T, buf: BytesMut) -> FramedRead2<T> {
+    FramedRead2 {
+        inner: inner,
+        eof: false,
+        is_readable: false,
+        buffer: buf,
+    }
+}
+
 impl<T> FramedRead2<T> {
     pub fn get_ref(&self) -> &T {
         &self.inner
@@ -226,6 +235,10 @@ impl<T> FramedRead2<T> {
 
     pub fn into_inner(self) -> T {
         self.inner
+    }
+
+    pub fn into_parts(self) -> (T, BytesMut) {
+        (self.inner, self.buffer)
     }
 
     pub fn get_mut(&mut self) -> &mut T {

--- a/src/framed_read.rs
+++ b/src/framed_read.rs
@@ -219,11 +219,15 @@ pub fn framed_read2<T>(inner: T) -> FramedRead2<T> {
     }
 }
 
-pub fn framed_read2_with_buffer<T>(inner: T, buf: BytesMut) -> FramedRead2<T> {
+pub fn framed_read2_with_buffer<T>(inner: T, mut buf: BytesMut) -> FramedRead2<T> {
+    if buf.capacity() < INITIAL_CAPACITY {
+        let bytes_to_reserve = INITIAL_CAPACITY - buf.capacity();
+        buf.reserve(bytes_to_reserve);
+    }
     FramedRead2 {
         inner: inner,
         eof: false,
-        is_readable: false,
+        is_readable: buf.len() > 0,
         buffer: buf,
     }
 }

--- a/src/framed_write.rs
+++ b/src/framed_write.rs
@@ -156,7 +156,11 @@ pub fn framed_write2<T>(inner: T) -> FramedWrite2<T> {
     }
 }
 
-pub fn framed_write2_with_buffer<T>(inner: T, buf: BytesMut) -> FramedWrite2<T> {
+pub fn framed_write2_with_buffer<T>(inner: T, mut buf: BytesMut) -> FramedWrite2<T> {
+    if buf.capacity() < INITIAL_CAPACITY {
+        let bytes_to_reserve = INITIAL_CAPACITY - buf.capacity();
+        buf.reserve(bytes_to_reserve);
+    }
     FramedWrite2 {
         inner: inner,
         buffer: buf,

--- a/src/framed_write.rs
+++ b/src/framed_write.rs
@@ -156,6 +156,13 @@ pub fn framed_write2<T>(inner: T) -> FramedWrite2<T> {
     }
 }
 
+pub fn framed_write2_with_buffer<T>(inner: T, buf: BytesMut) -> FramedWrite2<T> {
+    FramedWrite2 {
+        inner: inner,
+        buffer: buf,
+    }
+}
+
 impl<T> FramedWrite2<T> {
     pub fn get_ref(&self) -> &T {
         &self.inner
@@ -163,6 +170,10 @@ impl<T> FramedWrite2<T> {
 
     pub fn into_inner(self) -> T {
         self.inner
+    }
+
+    pub fn into_parts(self) -> (T, BytesMut) {
+        (self.inner, self.buffer)
     }
 
     pub fn get_mut(&mut self) -> &mut T {


### PR DESCRIPTION
A successor push request of #43 which makes that pull request obsolete.

I added a function to replace the codec of the Framed object.

My usecase for this are websockets. It starts with a simple line-based codec (or http-codec). After a connection upgrade to websockets are negotiogated, the frames change to a different codec.

If the codec change happends to occur after the first websocket was received by the tcp-stream, I am afraid those bytes are lost. So I added a simpel function to prevent this race condition by replacing the existing codec with a new codec and reuse the buffers.