### PR TITLE
Get the codec back from the Framed

### DIFF
--- a/tests/framed.rs
+++ b/tests/framed.rs
@@ -53,10 +53,11 @@ impl AsyncRead for DontReadIntoThis {}
 fn can_read_from_existing_buf() {
     let parts = FramedParts {
         inner: DontReadIntoThis,
+        codec: U32Codec,
         readbuf: vec![0, 0, 0, 42].into(),
         writebuf: BytesMut::with_capacity(0),
     };
-    let framed = Framed::from_parts(parts, U32Codec);
+    let framed = Framed::from_parts(parts);
 
     let num = framed
         .into_future()
@@ -73,10 +74,11 @@ fn can_read_from_existing_buf() {
 fn external_buf_grows_to_init() {
     let parts = FramedParts {
         inner: DontReadIntoThis,
+        codec: U32Codec,
         readbuf: vec![0, 0, 0, 42].into(),
         writebuf: BytesMut::with_capacity(0),
     };
-    let framed = Framed::from_parts(parts, U32Codec);
+    let framed = Framed::from_parts(parts);
     let FramedParts { readbuf, .. } = framed.into_parts();
 
     assert_eq!(readbuf.capacity(), INITIAL_CAPACITY);
@@ -86,10 +88,11 @@ fn external_buf_grows_to_init() {
 fn external_buf_does_not_shrink() {
     let parts = FramedParts {
         inner: DontReadIntoThis,
+        codec: U32Codec,
         readbuf: vec![0; INITIAL_CAPACITY * 2].into(),
         writebuf: BytesMut::with_capacity(0),
     };
-    let framed = Framed::from_parts(parts, U32Codec);
+    let framed = Framed::from_parts(parts);
     let FramedParts { readbuf, .. } = framed.into_parts();
 
     assert_eq!(readbuf.capacity(), INITIAL_CAPACITY * 2);


### PR DESCRIPTION
I think not only the buffers(aka Framedparts) but also the codec and the underlying I/O are needed to be unpack.

Generally, the codec keeps its state. To recreate the Framed object, it needs its underlying I/O, buffers, and the codec as well in some cases, or a new codec in other cases. So we can replace any of them if needed.

In my use case, I need to dispatch underlying I/O to different threads, we need to get the buffers and codec back, to recreate the framed object in the other thread.

I think we should put codec in the FramedParts struct as well.

For a unified interface, the return value of the `into_parts` method and the parameters of the `from_parts` should be corresponding.

So here comes the PR, which is based on <del>#43</del> #45.