### PR TITLE
Add `Framed::into_parts_and_codec` as temporary solution for #53

### DIFF
--- a/src/framed.rs
+++ b/src/framed.rs
@@ -95,6 +95,22 @@ impl<T, U> Framed<T, U> {
 	    let (inner, writebuf) = inner.into_parts();
         FramedParts { inner: inner.0, readbuf: readbuf, writebuf: writebuf }
     }
+
+    /// Consumes the `Frame`, returning its underlying I/O stream and the buffer
+    /// with unprocessed data, and also the current codec state.
+    ///
+    /// Note that care should be taken to not tamper with the underlying stream
+    /// of data coming in as it may corrupt the stream of frames otherwise
+    /// being worked with.
+    ///
+    /// Note that this function will be removed once the codec has been
+    /// integrated into `FramedParts` in a new version (see
+    /// [#53](https://github.com/tokio-rs/tokio-io/pull/53)).
+    pub fn into_parts_and_codec(self) -> (FramedParts<T>, U) {
+        let (inner, readbuf) = self.inner.into_parts();
+        let (inner, writebuf) = inner.into_parts();
+        (FramedParts { inner: inner.0, readbuf: readbuf, writebuf: writebuf }, inner.1)
+    }
 }
 
 impl<T, U> Stream for Framed<T, U>


### PR DESCRIPTION
Needs to be removed once codec becomes a part of `FramedParts`.  As discussed in #53.