### PR TITLE
Make framed method usable with more types

### DIFF
--- a/src/framed.rs
+++ b/src/framed.rs
@@ -19,8 +19,6 @@ pub struct Framed<T, U> {
 pub struct Fuse<T, U>(pub T, pub U);
 
 pub fn framed<T, U>(inner: T, codec: U) -> Framed<T, U>
-    where T: AsyncRead + AsyncWrite,
-          U: Decoder + Encoder,
 {
     Framed {
         inner: framed_read2(framed_write2(Fuse(inner, codec))),


### PR DESCRIPTION
Previously, framed required that the self type
was an AsyncRead and an AsyncWrite and that
codec was an Encoder and Decoder.

This commit relaxes that restriction to allow
using framed with types which are only AsyncRead
or AsyncWrite, or codecs which implement only
Encoder or Decoder.