### PR TITLE
Add accessors for max_frame_length to length_delimited::FramedWrite

### DIFF
--- a/src/length_delimited.rs
+++ b/src/length_delimited.rs
@@ -386,6 +386,24 @@ impl<T: AsyncWrite, B: IntoBuf> FramedWrite<T, B> {
 }
 
 impl<T, B: IntoBuf> FramedWrite<T, B> {
+    /// Returns the current max frame setting
+    ///
+    /// This is the largest size this codec will write to the wire. Larger
+    /// frames will be rejected.
+    pub fn max_frame_length(&self) -> usize {
+        self.builder.max_frame_len
+    }
+
+    /// Updates the max frame setting.
+    ///
+    /// The change takes effect the next time a frame is encoded. In other
+    /// words, if a frame is currently in process of being encoded with a frame
+    /// size greater than `val` but less than the max frame length in effect
+    /// before calling this function, then the frame will be allowed.
+    pub fn set_max_frame_length(&mut self, val: usize) {
+        self.builder.max_frame_length(val);
+    }
+
     /// Returns a reference to the underlying I/O stream wrapped by
     /// `FramedWrite`.
     ///


### PR DESCRIPTION
This is follows the change introduced on #65, adding the same max_frame_len accessors to length_delimited::FramedWrite.

I would also like to add those to length_delimited::Framed, but since it contains both a FramedRead and FramedWrite, each with it's own copy of the builder, I wasn't sure what was the best choice:
 * Add separate accessors for the read and write max_frame_length. I find this a bit confusing to mix with the builder approach.
 * Assume both max_frame_length values are meant to remain the same, so provide a single accessor that gets either and sets both. This can lead to confusion too imho.
 * Add mut accessors for the FramedRead and FramedWrite parts, or their builders. Not sure we want that as part of the API (?)

As a separate topic, I was looking at the max_frame_length since it's what I needed to use for my lib, but I guess it could make sense for the rest of attributes of the Builder. This could be a point in favour of just exposing access to the builder?

I wonder if there would be a bigger and more elegant change to have both read/write parts use the same builder, or something more similar to the regular tokio-io codecs. Probably out of the scope for this specific PR, and I'm still getting familiar with tokio anyway :)